### PR TITLE
Fix invalid syntax

### DIFF
--- a/locale/flarum-likes.yml
+++ b/locale/flarum-likes.yml
@@ -9,7 +9,7 @@ flarum-likes:
 
     # These strings are used in the Permissions page of the admin interface.
     permissions:
-      like_posts_label: "Gefällt mir" bei Beiträgen
+      like_posts_label: "\"Gefällt mir\" bei Beiträgen"
 
   # Strings in this namespace are used by the forum user interface.
   forum:


### PR DESCRIPTION
Quotes need to be escaped, otherwise it breaks the yaml reader.

Thanks for looking into this.